### PR TITLE
tce-bootload: fix script execution

### DIFF
--- a/usr/bin/tce-bootload
+++ b/usr/bin/tce-bootload
@@ -279,7 +279,7 @@ for p in stlst:
 		if showapps:
 			print(p + ' ', end="")
 		if os.access( script, os.X_OK) == True:
-			os.system('sudo script')
+			os.system('sudo %s' % script)
 		sys.exit(0)
 	else:
 		if forks >= maxforks:


### PR DESCRIPTION
A silly python mistake, I guess I did not test well enough.