### PR TITLE
Rename function "autoscan" to "tc_autoscan"

### DIFF
--- a/etc/init.d/tc-config
+++ b/etc/init.d/tc-config
@@ -412,7 +412,7 @@ if [ -n "$TCVD" ]; then
 	TCVD_DEVICE="${TCVD%%/*}"
 	TCVD_LOOPFILE="${TCVD#*/}"
 	if [ "$TCVD_DEVICE" == "$TCVD_LOOPFILE" ]; then
-		TCVD_DEVICE="$(autoscan $TCVD_LOOPFILE 'f')"
+		TCVD_DEVICE="$(tc_autoscan $TCVD_LOOPFILE 'f')"
 	fi   
 	PARTITION="${TCVD_DEVICE##/dev/}"
 	find_mountpoint "$PARTITION"

--- a/etc/init.d/tc-functions
+++ b/etc/init.d/tc-functions
@@ -106,7 +106,7 @@ find_mountpoint() {
  MOUNTPOINT="$(grep -i ^$D2\  /etc/fstab|awk '{print $2}'|head -n 1)"
 }
 
-autoscan(){
+tc_autoscan(){
 FOUND=""
 for DEVICE in `autoscan-devices`; do
    find_mountpoint $DEVICE

--- a/etc/init.d/tc-restore.sh
+++ b/etc/init.d/tc-restore.sh
@@ -35,7 +35,7 @@ if [ -n "$PROTECT" ]; then
 		DEVICE="$(echo $TCE|cut -f3- -d/)"
 	fi
 	if [ -z "$DEVICE" ]; then
-		DEVICE=`autoscan "$MYDATA".tgz.bfe 'f'`
+		DEVICE=`tc_autoscan "$MYDATA".tgz.bfe 'f'`
 	fi
 	if [ -n "$DEVICE" ]; then
 		/usr/bin/filetool.sh -r "$DEVICE"
@@ -52,7 +52,7 @@ if [ -z "$DEVICE" ]; then
 	if [ -n "$TCEDIR" ]; then
 		DEVICE="$TCEDIR"
 	else
-		DEVICE=`autoscan "$MYDATA".tgz 'f'`
+		DEVICE=`tc_autoscan "$MYDATA".tgz 'f'`
 	fi
 fi
 

--- a/usr/bin/tce-setup
+++ b/usr/bin/tce-setup
@@ -9,7 +9,7 @@ read USER < /etc/sysconfig/tcuser
 TCEINSTALLED="/usr/local/tce.installed"
 
 process_normal_tcedir() {
-	[ -z "$TCE" ] && TCE="$(autoscan 'tce' 'd')"/tce
+	[ -z "$TCE" ] && TCE="$(tc_autoscan 'tce' 'd')"/tce
 	if [ "$TCE" != "/tce" ]; then
 		TCE_DEVICE="${TCE%%/*}"
 		TCE_DIR="${TCE#*/}"
@@ -157,7 +157,7 @@ fi
 # If nothing loaded then also check for pseudo CD, e.g., isohybrid
 if [ "$CDE" -a -z "$CDELIST" ]; then
 	sleep 5
-	DEV="$(autoscan 'cde' 'd')"
+	DEV="$(tc_autoscan 'cde' 'd')"
 	process_CD
 fi
 

--- a/usr/bin/tce-update
+++ b/usr/bin/tce-update
@@ -230,7 +230,7 @@ echo -n "${YELLOW}Checking for Easy Mode Operation... ${NORMAL}"
 [ "$TCE" == "/tmp/tce/" ] && TCE=""
 TCE="${TCE#/mnt/}"
 # Next search for tce
-[ -z "$TCE" ] && TCE="$(autoscan 'tce' 'd')"/tce
+[ -z "$TCE" ] && TCE="$(tc_autoscan 'tce' 'd')"/tce
 TCE_DEVICE="${TCE%%/*}"
 TCE_DIR="${TCE#*/}"
 TCEDIR=/mnt/"$TCE_DEVICE"/"$TCE_DIR"


### PR DESCRIPTION
to prevent clashes with the GNU Autotools
(polikuo)

Commands:
cd Core-scripts
find \( -type d -name .git -prune \) -o -type f -print0 | xargs -0 sed -i "s:autoscan :tc_autoscan :g;s:autoscan(:tc_autoscan(:g"