### PR TITLE
exitcheck

### DIFF
--- a/opt/shutdown.sh
+++ b/opt/shutdown.sh
@@ -3,6 +3,13 @@
 useBusybox
 # put user shutdown commands here
 
+ACTION="$1"
+case $ACTION in
+	reboot);;
+	shutdown);;
+	*);;
+esac
+
 # If no backup of home was done then loop through valid users to clean up.
 if [ ! -e /tmp/backup_done ] || ! grep -q "^home" /opt/.filetool.lst; then
   awk 'BEGIN { FS=":" }  $3 >= 1000 && $1 != "nobody" { print $1 }' /etc/passwd > /tmp/users

--- a/usr/bin/exitcheck.sh
+++ b/usr/bin/exitcheck.sh
@@ -5,9 +5,10 @@
 . /etc/init.d/tc-functions
 useBusybox
 
-[ -x /opt/shutdown.sh ] && /opt/shutdown.sh
-
 ACTION="$1"
+
+[ -x /opt/shutdown.sh ] && /opt/shutdown.sh $ACTION
+
 case "$ACTION" in
   reboot )
     sudo /sbin/reboot


### PR DESCRIPTION
For users to be able to perform different tasks at shutdown or reboot, /opt/shutdown needs to know what action is being performed