### PR TITLE
tce-setup: No needless change of tce/onboot.lst timestamp during boot

### DIFF
--- a/usr/bin/tce-setup
+++ b/usr/bin/tce-setup
@@ -60,7 +60,7 @@ process_normal_tcedir() {
 setupExtnDirs() {
 	[ -d "$MOUNTPOINT"/"$TCE_DIR"/optional ] || mkdir -p "$MOUNTPOINT"/"$TCE_DIR"/optional
 	[ -d "$MOUNTPOINT"/"$TCE_DIR"/ondemand ] || mkdir -p "$MOUNTPOINT"/"$TCE_DIR"/ondemand
-	touch "$MOUNTPOINT"/"$TCE_DIR"/onboot.lst
+	[ -f "$MOUNTPOINT"/"$TCE_DIR"/onboot.lst ] || touch "$MOUNTPOINT"/"$TCE_DIR"/onboot.lst
 	chown -R "$USER".staff "$MOUNTPOINT"/"$TCE_DIR" 2>/dev/null
 	chmod -R g+w "$MOUNTPOINT"/"$TCE_DIR" 2>/dev/null
 }


### PR DESCRIPTION
Boot process currently changes timestamp of tce/onboot.lst. This causes user to be surprised when backing up TCL box because many backup utilities (e.g., rsync, lftp) are timestamp-aware and will think that onboot.lst has been changed. This commit avoids the needless change to tce/onboot.lst's timestamp during boot process.