### PR TITLE
filetool.sh: Alert the user when backup fails

### DIFF
--- a/usr/bin/filetool.sh
+++ b/usr/bin/filetool.sh
@@ -186,7 +186,7 @@ if [ "$BACKUP" ] ; then
     rotdash $!
     sync
     [ -s /tmp/backup_status ] && sed -i '/socket ignored/d' /tmp/backup_status 2>/dev/null
-    [ -s /tmp/backup_status ] && exit 1
+    [ -s /tmp/backup_status ] && { echo -e "\nThere was an issue, see /tmp/backup_status."; exit 1; }
     touch /tmp/backup_done
   fi
   if [ -f /etc/sysconfig/bfe ]; then


### PR DESCRIPTION
Backup operation currently fails silently--the only difference between successful backup and failed backup is that successful one outputs "Done." at end of operation. Because of the silent failures, I've had a non-existent files in my .filetool.lst for several months now. With this commit, filetool.sh now alerts the user that there was a problem and tells user where to look for clues.