### PR TITLE
tc-config: no gratuitous permissions changes in /opt

### DIFF
--- a/etc/init.d/tc-config
+++ b/etc/init.d/tc-config
@@ -478,9 +478,11 @@ if [ -n "$MYOPT" ]; then
 				[ -d "$MOUNTPOINT"/opt ] || mkdir "$MOUNTPOINT"/opt
 				yes n | cp -ai /opt/* /opt/.[!.]* "$MOUNTPOINT"/opt/ 2>/dev/null
 				mount --bind "$MOUNTPOINT"/opt/ /opt/
-				chgrp -R staff /opt/ >/dev/null 2>&1
-				chmod -R g+w /opt/ >/dev/null 2>&1
-				chmod g+s /opt/ >/dev/null 2>&1
+				for system_file in backgrounds .filetool.lst .xfiletool.lst bootlocal.sh bootsync.sh shutdown.sh tcemirror; do
+					chgrp -R staff /opt/"$system_file" >/dev/null 2>&1
+					chmod -R g+w /opt/"$system_file" >/dev/null 2>&1
+					chmod g+s /opt/"$system_file" >/dev/null 2>&1
+				done
 			;;
 		esac
 

--- a/etc/init.d/tc-config
+++ b/etc/init.d/tc-config
@@ -478,6 +478,11 @@ if [ -n "$MYOPT" ]; then
 				[ -d "$MOUNTPOINT"/opt ] || mkdir "$MOUNTPOINT"/opt
 				yes n | cp -ai /opt/* /opt/.[!.]* "$MOUNTPOINT"/opt/ 2>/dev/null
 				mount --bind "$MOUNTPOINT"/opt/ /opt/
+				# adjust the /opt directory itself:
+				chgrp staff /opt >/dev/null 2>&1
+				chmod g+w /opt >/dev/null 2>&1
+				chmod g+s /opt >/dev/null 2>&1
+				# inside /opt, adjust only system files:
 				for system_file in backgrounds .filetool.lst .xfiletool.lst bootlocal.sh bootsync.sh shutdown.sh tcemirror; do
 					chgrp -R staff /opt/"$system_file" >/dev/null 2>&1
 					chmod -R g+w /opt/"$system_file" >/dev/null 2>&1


### PR DESCRIPTION
I have private ssh keys in a subdirectory of my persistent /opt. Such keys should **not** have g+w permission (openssh actually refuses to use the keys with such permissions). It's heavy-handed for tc-config to recursively change permissions of everything in /opt--it should only change permissions of system files, assume everything else belongs to the user and leave it alone. Do you think this commit could make it into TCL12?