### PR TITLE
busybox 1.34 will require that "break" used in awk scripts must be us…

### DIFF
--- a/usr/bin/select
+++ b/usr/bin/select
@@ -22,11 +22,11 @@ function read_console() {
 END {
 	if ( NR < 1 ) {
 		print "q" > answer
-		break
+		exit
 	}
 	if ( NR == 1 ) {
 		print A[1] > answer
-		break
+		exit
 	}
 	do {
 		system ("clear")


### PR DESCRIPTION
…ed within the context of a loop.

Fixes #23 