### PR TITLE
tce-update: for "list" and "query", default to system's tcedir

### DIFF
--- a/usr/bin/tce-update
+++ b/usr/bin/tce-update
@@ -216,8 +216,8 @@ gzip -d md5.db.gz
 # First test for interactive mode - passed parameters
 if [ -n "$1" ]; then
 	case $1 in
-		list) LIST=1; process_cmd "$2" ;;
-		query) QUERY=1; process_cmd "$2" ;;
+		list) LIST=1; process_cmd "${2:-$(readlink /etc/sysconfig/tcedir)}" ;;
+		query) QUERY=1; process_cmd "${2:-$(readlink /etc/sysconfig/tcedir)}" ;;
 		update) unset QUERY; process_cmd "$2" ;;
 	esac
 fi


### PR DESCRIPTION
If user does not specify a directory for "tce-update list" or "tce-update query", then the script should assume the system's default tcedir (discoverable by following /etc/sysconfig/tcedir). [The same could probably also be done for "tce-update update" but I don't exactly understand the purpose of "tce-update update" so I didn't mess with it.]