### PR TITLE
tce: allow script to exit normally without stdout

### DIFF
--- a/usr/bin/tce
+++ b/usr/bin/tce
@@ -2,7 +2,7 @@
 # Tiny Core Browser
 # (c) Robert Shingledecker 2009-2012
 . /etc/init.d/tc-functions
-trap 'echo && exit 1 1>&2' 1 2 15
+trap 'echo; exit 1 1>&2' 1 2 15
 
 searchInfoList() {
 	clear


### PR DESCRIPTION
tce enters endless loop and drives CPU usage way up if terminal emulator is closed while tce is running. This change allows tce to exit when terminal emulator is closed.