### PR TITLE
tce-update: add option to skip dependency check

### DIFF
--- a/usr/bin/tce-update
+++ b/usr/bin/tce-update
@@ -80,7 +80,7 @@ upgrade(){
 
 
 check_dependencies(){
-	[ -n "$SKIPDEPCHECK ] && return
+	[ -n "$SKIPDEPCHECK" ] && return
 #	echo "${BLUE}Checking dependencies:${NORMAL}"
 	DEPS="$(/bin/busybox find "$UPGRADE_DIR" -regex '.*\.tcz\.dep$' | sort)"
 	[ -f  $TCEDIR/tcz-black.lst ] && DEPS=$(echo $DEPS | grep -v -f $TCEDIR/tcz-black.lst)

--- a/usr/bin/tce-update
+++ b/usr/bin/tce-update
@@ -80,6 +80,7 @@ upgrade(){
 
 
 check_dependencies(){
+	[ -n "$SKIPDEPCHECK ] && return
 #	echo "${BLUE}Checking dependencies:${NORMAL}"
 	DEPS="$(/bin/busybox find "$UPGRADE_DIR" -regex '.*\.tcz\.dep$' | sort)"
 	[ -f  $TCEDIR/tcz-black.lst ] && DEPS=$(echo $DEPS | grep -v -f $TCEDIR/tcz-black.lst)
@@ -201,6 +202,10 @@ process_cmd(){
 }
 
 # Main
+if [ "$1" = "--skip-dependency-check" ]; then
+	SKIPDEPCHECK=1	
+	shift
+fi
 cd /tmp
 ERRLIST="upgrade_errors.lst"
 > "$ERRLIST"


### PR DESCRIPTION
In some contexts (e.g., immediately after syncing .dep files, then tce-audit builddb, then tce-audit fetchmissing) tce-update's dependency check is guaranteed to accomplish nothing except waste CPU cycles and the user's time.