### PR TITLE
tce-audit: md5check update

### DIFF
--- a/usr/bin/tce-audit
+++ b/usr/bin/tce-audit
@@ -222,7 +222,7 @@ md5check() {
 	done
 
 	if [ $ERRORS -eq 0 ]; then
-		echo "OK: md5sums of all extensions in tce/optional are correct"
+		echo "OK: all md5sums are correct"
 		exit 0
 	else
 		exit 1


### PR DESCRIPTION
Success message should not have hardcoded path, since user can specify a custom path ("tce-audit md5check /path/to/tcedir"). Sorry for not realizing this with my original pull request.