### PR TITLE
tce-update: allow tcedir/optional to be a symlink

### DIFF
--- a/usr/bin/tce-update
+++ b/usr/bin/tce-update
@@ -82,7 +82,7 @@ upgrade(){
 check_dependencies(){
 	[ -n "$SKIPDEPCHECK" ] && return
 #	echo "${BLUE}Checking dependencies:${NORMAL}"
-	DEPS="$(/bin/busybox find "$UPGRADE_DIR" -regex '.*\.tcz\.dep$' | sort)"
+	DEPS="$(/bin/busybox find -L "$UPGRADE_DIR" -regex '.*\.tcz\.dep$' | sort)"
 	[ -f  $TCEDIR/tcz-black.lst ] && DEPS=$(echo $DEPS | grep -v -f $TCEDIR/tcz-black.lst)
 	for F in $DEPS; do
 		for TARGET in `cat "$F"`; do
@@ -167,7 +167,7 @@ process_dir(){
 		echo "$UPGRADE_DIR${NORMAL}"
 		[ "$QUERY" ] && echo "${BLUE}The following extensions need to be updated!${NORMAL}"
 	fi
-	FILES="$(/bin/busybox find "$UPGRADE_DIR" -regex '.*\.tcz\.md5\.txt$' | sort)"
+	FILES="$(/bin/busybox find -L "$UPGRADE_DIR" -regex '.*\.tcz\.md5\.txt$' | sort)"
 	[ -f  $TCEDIR/tcz-black.lst ] && FILES="$(echo "$FILES" | grep -v -f $TCEDIR/tcz-black.lst)"
 	for F in $FILES; do
 		if [ "$LIST" ]; then


### PR DESCRIPTION
On systems where /etc/sysconfig/tcedir/optional is a symlink, tce-update currently does not work--it cannot find any md5 files and immediately exits saying "Your system is up-to-date" (even when extensions are not actually up-to-date). Using "-L" flag to find fixes this.