### PR TITLE
update-everything: added safety checks

### DIFF
--- a/usr/bin/update-everything
+++ b/usr/bin/update-everything
@@ -1,7 +1,7 @@
 #!/bin/busybox ash
 
-# update-everything v8.0 (December 17, 2023)
-# by Bruno "GNUser" Dantas, with special thanks to jazzbiker and Rich
+# update-everything v9.0 (December 21, 2023)
+# by Bruno "GNUser" Dantas, with special thanks to jazzbiker, Rich, Paul_123
 # GPLv3
 
 # Purpose: Do a full TCL system update as quickly and efficiently as possible, leaving custom extensions intact 
@@ -12,13 +12,20 @@ export PATH
 
 main()
 {
-	echo "Looking for changed .dep files..."
-	get_depdb
-	generate_dep_files
-	fix_missing_and_extraneous_dep_files
-	sync_dep_files
+	rm -rf "$TMPDIR"; mkdir "$TMPDIR"; cd "$TMPDIR"
+	. /etc/init.d/tc-functions
+	getMirror
 
-	if $DEP_FILES_UPDATED; then
+	echo "Downloading and preparing databases..."
+	get "$DEPDBGZ"; extract "$DEPDBGZ"; sanity_check "$DEPDB"
+	get "$MD5DBGZ"; extract "$MD5DBGZ"; sanity_check "$MD5DB"
+	generate_dep_files
+
+	echo "Syncing .dep files..."
+	fix_missing_and_extraneous_dep_files
+	update_dep_files
+
+	if $DEP_FILES_CHANGED; then
 		echo "Building package database..."
 		tce-audit builddb
 		echo "Looking for missing dependencies..."
@@ -28,43 +35,61 @@ main()
 	echo "Updating extensions..."
 	tce-update --skip-dependency-check
 
-	rm -rf $DEPDIR
+	cleanup
 	exit 0
 }
 
-get_depdb()
+get()
 {
-	rm -rf "$DEPDIR"; mkdir -p "$DEPDIR"
-	cd "$DEPDIR"
-	. /etc/init.d/tc-functions
-	getMirror
-	wget -q "$MIRROR"/"$DBGZ"
-	gunzip -kf "$DBGZ"
+	if ! wget -q "$MIRROR"/"$1"; then
+		echo "Download of $1 failed. Aborting."
+		exit 1
+	fi
+}
+
+extract()
+{
+	if ! gunzip -kf "$1"; then
+		echo "Error extracting $1. Aborting."
+		exit 1
+	fi
+}
+
+sanity_check()
+{
+	if ! grep -q "zstd.tcz" "$1"; then
+		echo "$1 failed sanity check. Aborting."
+		exit 1
+	fi
 }
 
 generate_dep_files()
 {
+	mkdir "$DEPDIR"
+	cp "$TMPDIR/$DEPDB" "$DEPDIR"
+	cd "$DEPDIR"
 	awk 'BEGIN {FS="\n";RS=""} { out=$1".dep"; for (i=2; i<=NF; i++) printf("%s\n", $(i)) >out; close(out) }' dep.db
 }
 
 fix_missing_and_extraneous_dep_files()
 {
-	for md5file in $(find $OPTIONALDIR -name '*.md5.txt' -exec basename {} \;); do
-		depfile="${md5file%.md5.txt}.dep"
+	for md5file in $(find -L $OPTIONALDIR -name '*.md5.txt' -exec basename {} \;); do
+		depfile="${md5file%.md5.txt}.dep" # i.e., foo.tcz.dep
+		tczname="${md5file%.md5.txt}" # i.e., foo.tcz
 		if [ -f $DEPDIR/$depfile ] && [ ! -f $OPTIONALDIR/$depfile ]; then
 			echo "$depfile is missing, adding it..."
 			cp $DEPDIR/$depfile $OPTIONALDIR
-			DEP_FILES_UPDATED=true
-		elif [ ! -f $DEPDIR/$depfile ] && [ -f $OPTIONALDIR/$depfile ]; then
+			DEP_FILES_CHANGED=true
+		elif [ ! -f $DEPDIR/$depfile ] && [ -f $OPTIONALDIR/$depfile ] && grep -q " $tczname" /tmp/md5.db; then
 			echo "$depfile is extraneous, removing it..."
 			rm $OPTIONALDIR/$depfile
 		fi
 	done
 }
 
-sync_dep_files()
+update_dep_files()
 {
-	for md5file in $(find $OPTIONALDIR -name '*.md5.txt' -exec basename {} \;); do
+	for md5file in $(find -L $OPTIONALDIR -name '*.md5.txt' -exec basename {} \;); do
 		depfile="${md5file%.md5.txt}.dep"
 		if [ ! -f $OPTIONALDIR/$depfile ]; then # extension does not have a dep file
 			continue
@@ -74,16 +99,25 @@ sync_dep_files()
 		else
 			echo "$depfile has changed, updating it..."
 			cp $DEPDIR/$depfile $OPTIONALDIR
-			DEP_FILES_UPDATED=true
+			DEP_FILES_CHANGED=true
 		fi
 	done
 }
 
+cleanup()
+{
+	cd /tmp
+	rm -rf "$TMPDIR"
+}
+
 # internal variables, do not touch:
 OPTIONALDIR="/etc/sysconfig/tcedir/optional"
-DEPDIR="/tmp/depfiles"
-DB="dep.db"
-DBGZ="$DB.gz"
-DEP_FILES_UPDATED=false
+TMPDIR="/tmp/update-everything"
+DEPDIR="$TMPDIR/depfiles"
+DEPDB="dep.db"
+DEPDBGZ="$DEPDB.gz"
+MD5DB="md5.db"
+MD5DBGZ="$MD5DB.gz"
+DEP_FILES_CHANGED=false
 
 main


### PR DESCRIPTION
1. Error at any step of database file handling (download, extraction, sanity check) causes the update process to abort
2. More strict criteria must be met before a .dep file is deleted
3. "find" changed to "find -L" so that tcedir/optional can be a symlink