### PR TITLE
update-everything: add safety checks

### DIFF
--- a/usr/bin/update-everything
+++ b/usr/bin/update-everything
@@ -1,7 +1,7 @@
 #!/bin/busybox ash
 
-# update-everything v8.0 (December 17, 2023)
-# by Bruno "GNUser" Dantas, with special thanks to jazzbiker and Rich
+# update-everything v9.1 (December 21, 2023)
+# by Bruno "GNUser" Dantas, with special thanks to jazzbiker, Rich, Paul_123
 # GPLv3
 
 # Purpose: Do a full TCL system update as quickly and efficiently as possible, leaving custom extensions intact 
@@ -12,13 +12,19 @@ export PATH
 
 main()
 {
-	echo "Looking for changed .dep files..."
-	get_depdb
-	generate_dep_files
-	fix_missing_and_extraneous_dep_files
-	sync_dep_files
+	rm -rf "$TMPDIR"; mkdir "$TMPDIR"; cd "$TMPDIR"
+	. /etc/init.d/tc-functions
+	getMirror
 
-	if $DEP_FILES_UPDATED; then
+	echo "Downloading and preparing databases..."
+	download "$MD5DBGZ"; extract "$MD5DBGZ"; sanity_check_md5db
+	download "$DEPDBGZ"; extract "$DEPDBGZ"; generate_depdir; sanity_check_depdir
+
+	echo "Syncing .dep files..."
+	fix_missing_and_extraneous_dep_files
+	update_dep_files
+
+	if $DEP_FILES_CHANGED; then
 		echo "Building package database..."
 		tce-audit builddb
 		echo "Looking for missing dependencies..."
@@ -28,43 +34,68 @@ main()
 	echo "Updating extensions..."
 	tce-update --skip-dependency-check
 
-	rm -rf $DEPDIR
+	rm -rf "$TMPDIR"
 	exit 0
 }
 
-get_depdb()
+download()
 {
-	rm -rf "$DEPDIR"; mkdir -p "$DEPDIR"
-	cd "$DEPDIR"
-	. /etc/init.d/tc-functions
-	getMirror
-	wget -q "$MIRROR"/"$DBGZ"
-	gunzip -kf "$DBGZ"
+	if ! wget -q "$MIRROR"/"$1"; then
+		echo "Download of $1 failed. Aborting."
+		exit 1
+	fi
 }
 
-generate_dep_files()
+extract()
 {
-	awk 'BEGIN {FS="\n";RS=""} { out=$1".dep"; for (i=2; i<=NF; i++) printf("%s\n", $(i)) >out; close(out) }' dep.db
+	if ! gunzip -kf "$1"; then
+		echo "Error extracting $1. Aborting."
+		exit 1
+	fi
+}
+
+sanity_check_md5db()
+{
+	if ! grep -q " zstd.tcz" "$MD5DB"; then
+		echo "$MD5DB is missing or incomplete. Aborting."
+		exit 1
+	fi
+}
+
+generate_depdir()
+{
+	mkdir "$DEPDIR"
+	cp "$DEPDB" "$DEPDIR"
+	awk -v DEPDIR="$DEPDIR" 'BEGIN {FS="\n";RS=""} { out=DEPDIR"/"$1".dep"; for (i=2; i<=NF; i++) printf("%s\n", $(i)) >out; close(out) }' "$DEPDB"
+}
+
+sanity_check_depdir()
+{
+	if ! [ -f "$DEPDIR/zstd.tcz.dep" ]; then
+		echo "$DEPDIR is missing or incomplete. Aborting."
+		exit 1
+	fi
 }
 
 fix_missing_and_extraneous_dep_files()
 {
-	for md5file in $(find $OPTIONALDIR -name '*.md5.txt' -exec basename {} \;); do
-		depfile="${md5file%.md5.txt}.dep"
+	for md5file in $(find -L $OPTIONALDIR -name '*.md5.txt' -exec basename {} \;); do
+		depfile="${md5file%.md5.txt}.dep" # i.e., foo.tcz.dep
+		tczname="${md5file%.md5.txt}" # i.e., foo.tcz
 		if [ -f $DEPDIR/$depfile ] && [ ! -f $OPTIONALDIR/$depfile ]; then
 			echo "$depfile is missing, adding it..."
 			cp $DEPDIR/$depfile $OPTIONALDIR
-			DEP_FILES_UPDATED=true
-		elif [ ! -f $DEPDIR/$depfile ] && [ -f $OPTIONALDIR/$depfile ]; then
+			DEP_FILES_CHANGED=true
+		elif [ ! -f $DEPDIR/$depfile ] && [ -f $OPTIONALDIR/$depfile ] && grep -q " $tczname" /tmp/md5.db; then
 			echo "$depfile is extraneous, removing it..."
 			rm $OPTIONALDIR/$depfile
 		fi
 	done
 }
 
-sync_dep_files()
+update_dep_files()
 {
-	for md5file in $(find $OPTIONALDIR -name '*.md5.txt' -exec basename {} \;); do
+	for md5file in $(find -L $OPTIONALDIR -name '*.md5.txt' -exec basename {} \;); do
 		depfile="${md5file%.md5.txt}.dep"
 		if [ ! -f $OPTIONALDIR/$depfile ]; then # extension does not have a dep file
 			continue
@@ -74,16 +105,19 @@ sync_dep_files()
 		else
 			echo "$depfile has changed, updating it..."
 			cp $DEPDIR/$depfile $OPTIONALDIR
-			DEP_FILES_UPDATED=true
+			DEP_FILES_CHANGED=true
 		fi
 	done
 }
 
 # internal variables, do not touch:
 OPTIONALDIR="/etc/sysconfig/tcedir/optional"
-DEPDIR="/tmp/depfiles"
-DB="dep.db"
-DBGZ="$DB.gz"
-DEP_FILES_UPDATED=false
+TMPDIR="/tmp/update-everything"
+DEPDIR="$TMPDIR/depfiles"
+DEPDB="dep.db"
+DEPDBGZ="$DEPDB.gz"
+MD5DB="md5.db"
+MD5DBGZ="$MD5DB.gz"
+DEP_FILES_CHANGED=false
 
 main


### PR DESCRIPTION
1. Abort if error at any step of database file handling (download, extraction, sanity check)
2. More strict criteria must be met before a .dep file is deleted
3. "find" changed to "find -L" so that tcedir/optional can be a symlink