### PR TITLE
getTime.sh: support more than one server from dhcp

### DIFF
--- a/usr/bin/getTime.sh
+++ b/usr/bin/getTime.sh
@@ -1,5 +1,11 @@
 #!/bin/busybox ash
-# bmarkus - 26/02/2014
-
-NTPSERVER=$(cat /etc/sysconfig/ntpserver)
-/usr/sbin/ntpd -q -p $NTPSERVER
+if [ -f /etc/sysconfig/ntpserver ]; then
+        set $(cat /etc/sysconfig/ntpserver)
+        while [ "$1" != "" ]; do
+                NTPOPTS="$NTPOPTS -p $1"
+                shift
+        done
+else
+        NTPOPTS=""
+fi
+/usr/sbin/ntpd -q $NTPOPTS


### PR DESCRIPTION
If more than one NTP Server is configured in the dhcp server to be supplied to clients, the old script does not generate a valid commandline from it. ntpd allows multiple peers, each preceeded with a -p.