### PR TITLE
Add missing sudo to rmdir command in copyInstall().

### DIFF
--- a/usr/bin/tce-load
+++ b/usr/bin/tce-load
@@ -89,7 +89,7 @@ copyInstall() {
 		fi
 		sudo /bin/umount -d /mnt/test
 	fi
-	[ "$BOOTING" ] || rmdir /mnt/test
+	[ "$BOOTING" ] || sudo rmdir /mnt/test
 }
 
 update_system() {


### PR DESCRIPTION
sudo was used to create directory. sudo needs to be added to rmdir command.