### PR TITLE
tce-setup: add lnoptional bootcode

### DIFF
--- a/usr/bin/tce-setup
+++ b/usr/bin/tce-setup
@@ -58,6 +58,10 @@ process_normal_tcedir() {
 }
 
 setupExtnDirs() {
+	if [ -n "$TARGETOPTIONAL" ]; then	
+		[ -L "$MOUNTPOINT"/"$TCE_DIR"/optional ] && rm "$MOUNTPOINT"/"$TCE_DIR"/optional
+		ln -s "$MOUNTPOINT"/"$TCE_DIR"/"$TARGETOPTIONAL" "$MOUNTPOINT"/"$TCE_DIR"/optional
+	fi
 	[ -d "$MOUNTPOINT"/"$TCE_DIR"/optional ] || mkdir -p "$MOUNTPOINT"/"$TCE_DIR"/optional
 	[ -d "$MOUNTPOINT"/"$TCE_DIR"/ondemand ] || mkdir -p "$MOUNTPOINT"/"$TCE_DIR"/ondemand
 	[ -f "$MOUNTPOINT"/"$TCE_DIR"/"$TARGETLIST" ] || touch "$MOUNTPOINT"/"$TCE_DIR"/"$TARGETLIST"
@@ -108,6 +112,7 @@ for i in `cat /proc/cmdline`; do
 	case $i in
 		tce=*) TCE=${i#*=} ;;
 		lst=*) TARGETLIST=${i#*=} ;;
+		lnoptional=*) TARGETOPTIONAL=${i#*=} ;;
 	esac
 	case $i in
 		cde) CDE=1 ;;


### PR DESCRIPTION
For users who like having different tce/optional-foo directories for different use cases. This bootcode supplements the existing lst= bootcode.

Example usage: A user has tce/optional-wayland, tce/onboot.lst-wayland, tce/optional-X, and tce/onboot.lst-X. User would use `lst=onboot.lst-wayland lnoptional=optional-wayland` to boot the wayland extension set or `lst=onboot.lst-X lnoptional=optional-X` to boot the X extension set.

Note that if tce/optional exists and is a real directory, the lnoptional boot code fails silently without any harm done.