### PR TITLE
provides.sh: Add -f switch to show full paths

### DIFF
--- a/usr/bin/provides.sh
+++ b/usr/bin/provides.sh
@@ -211,6 +211,6 @@ else
 	then
 		awk 'BEGIN {FS="\n";RS=""} /'"${TARGET}"'/{i=2;while(i<=NF){if($i~/'"${TARGET}"'/)printf"%-30s : %s\n",$1,$i;i++;}}' "$LIST"
 	else
-		awk 'BEGIN {FS="\n";RS=""} /'"${TARGET}"'\n/{i=2;while(i<=NF){if($i~/'"${TARGET}"'$/)printf"%-30s : %s\n",$1,$i;i++;}}' "$LIST"
+		awk 'BEGIN {FS="\n";RS=""} /'"${TARGET}"'/{i=2;while(i<=NF){if($i~/'"${TARGET}"'$/)printf"%-30s : %s\n",$1,$i;i++;}}' "$LIST"
 	fi
 fi


### PR DESCRIPTION
This PR adds a `-f` script to `provides.sh` that has it output all the matched paths along with the name of the extension.

For example:
```ash
tc@box:/mnt/sda5/home/tc/Core-scripts$ ./usr/bin/provides.sh -f bin/lua
lua-5.4.tcz                    : /usr/local/bin/luac
lua-5.4.tcz                    : /usr/local/bin/lua
luajit-2.1-beta1.tcz           : /usr/local/bin/luajit-2.1.0-beta1
luajit.tcz                     : /usr/local/bin/luajit
luajit.tcz                     : /usr/local/bin/luajit-2.0.5
luarocks.tcz                   : /usr/local/bin/luarocks
luarocks.tcz                   : /usr/local/bin/luarocks-admin
```

I'm not sure what is meant to happen with the $VERSION.
