### PR TITLE
Use grep instead of reading the whole file with cat in stringinfile()

### DIFF
--- a/etc/init.d/tc-functions
+++ b/etc/init.d/tc-functions
@@ -24,9 +24,8 @@ useBusybox() {
 
 trim() { echo $1; }
 
-stringinfile(){
-case "$(cat $2)" in *$1*) return 0;; esac
-return 1
+stringinfile() {
+  grep -qm1 "$1" "$2"
 }
 
 stringinstring(){


### PR DESCRIPTION
stringinfile: use grep instead of reading the whole file with cat
-q silences grep, -m1 tells it to stop as soon as it finds something. Redirects the error level.

stringinstring: more simple syntax, works on sh.

```
tc@box:~$ cat test.sh
test() {
  [[ "$2" == *"$1"* ]]
}

test "oi" "o"
echo $?
test "oi" "oi"
echo $?
tc@box:~$ busybox sh test.sh
1
0
tc@box:~$

```