### PR TITLE
tc-functions: bug fix in getMajorVer

### DIFF
--- a/etc/init.d/tc-functions
+++ b/etc/init.d/tc-functions
@@ -283,7 +283,7 @@ echo ${verid#*=}
 
 getMajorVer() {
 fullver=$(getFullVer)
-echo ${fullver%.*}
+echo $fullver | grep -Eo '^[0-9]+'
 }
 
 getBuild() {


### PR DESCRIPTION
Currently, if full version is _17alpha1_ (for example), getMajorVer outputs _17alpha1_ rather than _17_ as expected. Downstream from this bug, getMirror sets the MIRROR variable to the nonexistent url http://repo.tinycorelinux.net/17alpha1.x/x86_64/tcz (rather than the expected _http://repo.tinycorelinux.net/17.x/x86_64/tcz_), breaking _tce-update_ and _update-everything_, among others. With this bug fix, getMajorVer always outputs the expected major version -> MIRROR is set to correct url -> everybody's happy :)