### PR TITLE
update-everything: default PATH with useBusybox

### DIFF
--- a/usr/bin/update-everything
+++ b/usr/bin/update-everything
@@ -8,9 +8,8 @@
 #   Custom extensions (i.e., those that don't have a .md5.txt file) are left alone.
 # Usage: $ update-everything
 
-# note: /usr/local/bin is required so that openssl can be used for https mirrors.
-PATH="/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin"
-export PATH
+. /etc/init.d/tc-functions
+useBusybox
 
 main()
 {


### PR DESCRIPTION
The intent of the script's original, limited PATH (PATH="/bin:/sbin:/usr/bin:/usr/sbin") was to run the script in a maximally controlled environment where only utilities in the base system were being used (i.e., it was a stronger version of useBusybox). The goal, of course, was to decrease interuser variability in the script's environment, thus decreasing the chance of unexpected behavior/bugs. If we're basically back to default PATH in order to support https mirrors, then there is no point in specifying a PATH in the script. But I would at least like to have a somewhat controlled environment with useBusybox.